### PR TITLE
feat: make utRun.run return promise instead of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ module.exports = {
         }
     },
     run: function(params, parent) {
-        this.runParams(params, parent).catch((err) => {
+        return this.runParams(params, parent).catch((err) => {
             console.error(err);
             process.abort();
         });


### PR DESCRIPTION
make utRun.run return promise instead of undefined so that the response including bus, ports, etc.. can be accessed from outside (i.e. from custom tests)