### PR TITLE
feat: bypass bus.importMethod if no method is specified in test spec

### DIFF
--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ function sequence(options, test, bus, flow, params) {
             return {
                 name: f.name || '',
                 methodName: f.method,
-                method: bus.importMethod(f.method),
+                method: f.method ? bus.importMethod(f.method) : (params) => (params),
                 params: (typeof f.params === 'function') ? when.lift(f.params) : () => f.params,
                 result: f.result,
                 error: f.error


### PR DESCRIPTION
bypass bus by omitting 'method' property in the test spec. Useful for custom test (i.e. rest requests with supertest) which are not strictly json-rpc.