### PR TITLE
fix: UIS-403 modify validation initialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,12 +40,14 @@ module.exports = {
         }
 
         if (implementation.validations instanceof Object) {
-            Object.keys(implementation.validations).forEach(function(routeConfigName) {
-                var module = implementation.modules[routeConfigName];
-                var routeConfig = implementation.validations[routeConfigName];
+            Object.keys(implementation.validations).forEach(function(validationKey) {
+                var routeConfigNames = validationKey.split('.');
+                var moduleName = routeConfigNames.length > 1 ? routeConfigNames.shift() : routeConfigNames;
+                var module = implementation.modules[moduleName];
+                var routeConfig = implementation.validations[validationKey];
                 module && Object.keys(routeConfig).forEach(function(value) {
                     module.routeConfig.push({
-                        method: routeConfigName + '.' + value,
+                        method: routeConfigNames.join('.') + '.' + value,
                         config: routeConfig[value]
                     });
                 });


### PR DESCRIPTION
Modify the way validations are initialized by checking the key passed from implementation.
The goal is to enable procedures to be validated without module name prefix in their filename.
Instead the relationship between them and the module they are into can be specified in the implementation by including the module name followed by dot. 
For example: 
Validations of procedures starting with policy in their filename and stored in user module can be included in implementation as  'user.policy': <require policy validations> 