### PR TITLE
WIP: switch to udp

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -77,8 +77,8 @@ module.exports = {
                     level: mergedConfig.console.level || 'trace',
                     stream: require('ut-log/udpStream'),
                     streamConfig: {
-                        host: 'localhost',
-                        port: 30001
+                        host: mergedConfig.console.host,
+                        port: mergedConfig.console.port
                     }
                 });
             }

--- a/debug.js
+++ b/debug.js
@@ -29,7 +29,7 @@ module.exports = {
                 logLevel: 'debug'
             },
             console: {
-                host: '127.0.0.1',
+                host: 'localhost',
                 port: 30001,
                 logLevel: 'info'
             },
@@ -75,14 +75,11 @@ module.exports = {
             if (mergedConfig.console) {
                 streams.push({
                     level: mergedConfig.console.level || 'trace',
-                    stream: require('ut-log/socketStream'),
+                    stream: require('ut-log/udpStream'),
                     streamConfig: {
-                        protocol: process.browser && global.location.protocol,
-                        host: mergedConfig.console.host,
-                        port: mergedConfig.console.port,
-                        objectMode: true
-                    },
-                    type: 'raw'
+                        host: 'localhost',
+                        port: 30001
+                    }
                 });
             }
             logFactory = new UTLog({

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lodash.merge": "4.6.0",
     "minimist": "1.2.0",
     "rc": "1.1.6",
-    "ut-log": ">=5.11.0-rc.0 <5.11.0",
+    "ut-log": "^5.11.0",
     "ut-port-registry": "^0.1.1",
     "when": "3.7.7"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-run",
-  "version": "8.3.1",
+  "version": "8.4.0-rc.0",
   "dependencies": {
     "loadtest": "2.2.1",
     "lodash.merge": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ut-run",
-  "version": "8.4.0-rc.0",
+  "version": "8.4.0-rc.1",
   "dependencies": {
     "loadtest": "2.2.1",
     "lodash.merge": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lodash.merge": "4.6.0",
     "minimist": "1.2.0",
     "rc": "1.1.6",
-    "ut-log": "^5.10.8",
+    "ut-log": ">=5.11.0-rc.0 <5.11.0",
     "ut-port-registry": "^0.1.1",
     "when": "3.7.7"
   },


### PR DESCRIPTION
Use the new stream in ut-log to send log messages through UDP to the console.
Note that we need to remove any console starting logic from ut-run and run the console as separate service, much like other services - it should have a life of it's own from security and other points of view. The way we start it should be the standard way of starting ports with ut-run. The code in ut-run will only stay for backwards compatibility for a while.

This is WIP, until we merge ut-log, when I can put the proper dependency.