### PR TITLE
fix: add ut-bus as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,9 @@
     "loadtest": "2.3.0",
     "minimist": "1.2.0",
     "rc": "1.2.6",
-    "ut-log": "^6.1.0-rc-bahur.1",
-    "ut-port": "^6.5.0"
-  },
-  "peerDependencies": {
-    "ut-bus": "^6.2.0-rc-bahur.1"
+    "ut-log": "^6.2.0",
+    "ut-port": "^6.6.0",
+    "ut-bus": "^6.5.0-rc-diesel.0"
   },
   "devDependencies": {
     "tap": "^10.7.3",


### PR DESCRIPTION
add ut-bus as a direct dependency