### PR TITLE
WIP: assign $test property to unexpected backend errors during tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -150,6 +150,7 @@ function sequence(options, test, bus, flow, params, parent) {
                                         }
                                         step.error.call(context, error, assert);
                                     } else {
+                                        bus.log.fatal?.(Object.assign(error, {$test: {step, test: options.name}}));
                                         throw error;
                                     }
                                 });


### PR DESCRIPTION
assign $test property to unexpected backend errors during tests.
Example:
![image](https://user-images.githubusercontent.com/6398208/153616528-87e7e4b2-9dde-4f45-95a1-3a8b1449fef3.png)
