### PR TITLE
fix: use step.method as step.name if no step.name specified

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -205,6 +205,8 @@ function convertStep(step, options) {
             description: step,
             cucumber: true
         };
+    } else if (!step.name && step.method) {
+        step.name = step.method;
     }
     if (step.cucumber === true) {
         step.arguments = step.match ? [step.match(step.description || '')] : [];


### PR DESCRIPTION
use step.method as step.name if no step.name specified